### PR TITLE
Implement auto-scroll text logging

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import com.example.kittmonitor.ui.AutoScrollText
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -37,6 +38,7 @@ class MainActivity : ComponentActivity() {
     private var scanCallback: ScanCallback? = null
     private var gatt: BluetoothGatt? = null
     private val statusTextState = mutableStateOf("")
+    private val logMessages = mutableStateListOf<String>()
 
     private val descriptorQueue =
         ConcurrentLinkedQueue<Pair<BluetoothGatt, BluetoothGattDescriptor>>()
@@ -74,7 +76,13 @@ class MainActivity : ComponentActivity() {
                                 style = MaterialTheme.typography.bodyLarge
                             )
                         }
-                        Spacer(modifier = Modifier.weight(1f))
+                        AutoScrollText(
+                            text = logMessages.joinToString("\n"),
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxWidth(),
+                            style = MaterialTheme.typography.bodyMedium.copy(color = Color.White)
+                        )
                     }
                 }
 
@@ -188,10 +196,14 @@ class MainActivity : ComponentActivity() {
                 characteristic: BluetoothGattCharacteristic
             ) {
                 val value = characteristic.value
+                val message = value?.decodeToString() ?: ""
                 Log.d(
                     "KITTMonitor",
-                    "Received update: ${value?.decodeToString()}"
+                    "Received update: $message"
                 )
+                runOnUiThread {
+                    logMessages.add(message)
+                }
             }
 
             override fun onDescriptorWrite(

--- a/app/src/main/java/com/example/kittmonitor/ui/AutoScrollText.kt
+++ b/app/src/main/java/com/example/kittmonitor/ui/AutoScrollText.kt
@@ -1,0 +1,50 @@
+package com.example.kittmonitor.ui
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.consume
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Text
+
+@Composable
+fun AutoScrollText(
+    text: String,
+    modifier: Modifier = Modifier,
+    style: TextStyle = TextStyle(fontSize = 14.sp)
+) {
+    var autoScroll by remember { mutableStateOf(true) }
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(text, autoScroll) {
+        if (autoScroll) {
+            scrollState.animateScrollTo(scrollState.maxValue)
+        }
+    }
+
+    Box(
+        modifier
+            .pointerInput(Unit) {
+                detectVerticalDragGestures(onDragStart = {
+                    autoScroll = false
+                }, onDrag = { change, dragAmount ->
+                    change.consume()
+                    scrollState.dispatchRawDelta(-dragAmount)
+                })
+            }
+            .pointerInput(Unit) {
+                detectTapGestures(onDoubleTap = {
+                    autoScroll = true
+                })
+            }
+            .verticalScroll(scrollState)
+    ) {
+        Text(text, style = style)
+    }
+}


### PR DESCRIPTION
## Summary
- add `AutoScrollText` component to toggle auto-scrolling based on user gestures
- display log messages from BLE characteristic notifications using the new component
- switch to manual mode when dragging, double tap to re-enable auto mode

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68537c8ffe548329897d3dfacb5492cb