### PR TITLE
Enable log saving to file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
         android:maxSdkVersion="30" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
         android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"


### PR DESCRIPTION
## Summary
- allow writing to external storage
- add a save button action that writes log messages to a text file
- include storage permission in runtime checks

## Testing
- `./gradlew test --dry-run` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --dry-run` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68538790ba808329924feeadd073c370