### PR TITLE
Add folder options

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -364,7 +364,7 @@ class MainActivity : ComponentActivity() {
     private fun openLocation(directory: File) {
         val relativePath = directory.absolutePath.substringAfter("/storage/emulated/0/")
         val encoded = Uri.encode(relativePath)
-        val uri = Uri.parse("content://com.android.externalstorage.documents/document/primary%3A$encoded")
+        val uri = Uri.parse("content://com.android.externalstorage.documents/document/primary:" + encoded)
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION

--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -99,13 +100,23 @@ class MainActivity : ComponentActivity() {
                                 contentAlignment = Alignment.CenterStart
                             ) {
                                 if (isConnectedState.value) {
-                                    IconButton(onClick = { saveLogsToFile() }) {
-                                        Icon(
-                                            imageVector = Icons.Default.Save,
-                                            contentDescription = "Save logs",
-                                            tint = Color.White,
-                                            modifier = Modifier.size(20.dp)
-                                        )
+                                    Row {
+                                        IconButton(onClick = { saveLogsToFile() }) {
+                                            Icon(
+                                                imageVector = Icons.Default.Save,
+                                                contentDescription = "Save logs",
+                                                tint = Color.White,
+                                                modifier = Modifier.size(20.dp)
+                                            )
+                                        }
+                                        IconButton(onClick = { openLogsDirectory() }) {
+                                            Icon(
+                                                imageVector = Icons.Default.Folder,
+                                                contentDescription = "Open logs directory",
+                                                tint = Color.White,
+                                                modifier = Modifier.size(20.dp)
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -333,6 +344,9 @@ class MainActivity : ComponentActivity() {
             .setTitle("Logs saved")
             .setMessage(file.absolutePath)
             .setNegativeButton("Close", null)
+            .setNeutralButton("Open Location") { _, _ ->
+                file.parentFile?.let { openLocation(it) }
+            }
             .setPositiveButton("View File") { _, _ -> openFile(file) }
             .show()
     }
@@ -344,6 +358,20 @@ class MainActivity : ComponentActivity() {
             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
         }
         startActivity(Intent.createChooser(intent, "Open file"))
+    }
+
+    private fun openLocation(directory: File) {
+        val uri: Uri = FileProvider.getUriForFile(this, "$packageName.provider", directory)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "resource/folder")
+            flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
+        }
+        startActivity(intent)
+    }
+
+    private fun openLogsDirectory() {
+        val dir = getExternalFilesDir(null)
+        dir?.let { openLocation(it) }
     }
 
     private fun formatMessage(uuid: UUID, value: String): AnnotatedString {

--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -346,7 +346,7 @@ class MainActivity : ComponentActivity() {
             .setMessage(file.absolutePath)
             .setNegativeButton("Close", null)
             .setNeutralButton("Open Location") { _, _ ->
-                file.parentFile?.let { openLocation(it) }
+                openLocation()
             }
             .setPositiveButton("View File") { _, _ -> openFile(file) }
             .show()
@@ -361,10 +361,12 @@ class MainActivity : ComponentActivity() {
         startActivity(Intent.createChooser(intent, "Open file"))
     }
 
-    private fun openLocation(directory: File) {
-        val relativePath = directory.absolutePath.substringAfter("/storage/emulated/0/")
-        val encoded = Uri.encode(relativePath)
-        val uri = Uri.parse("content://com.android.externalstorage.documents/document/primary:" + encoded)
+    private fun openLocation() {
+        val encoded = Uri.encode("Android/data/com.example.kittmonitor/files")
+        val uri = Uri.parse(
+            "content://com.android.externalstorage.documents/document/primary:" +
+                encoded
+        )
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
@@ -373,8 +375,7 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun openLogsDirectory() {
-        val dir = getExternalFilesDir(null)
-        dir?.let { openLocation(it) }
+        openLocation()
     }
 
     private fun formatMessage(uuid: UUID, value: String): AnnotatedString {

--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -47,6 +47,7 @@ import android.widget.Toast
 import android.app.AlertDialog
 import androidx.core.content.FileProvider
 import android.net.Uri
+import android.provider.DocumentsContract
 import androidx.annotation.RequiresApi
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.snapshotFlow
@@ -363,10 +364,10 @@ class MainActivity : ComponentActivity() {
     private fun openLocation(directory: File) {
         val uri: Uri = FileProvider.getUriForFile(this, "$packageName.provider", directory)
         val intent = Intent(Intent.ACTION_VIEW).apply {
-            setDataAndType(uri, "resource/folder")
+            setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION
         }
-        startActivity(intent)
+        startActivity(Intent.createChooser(intent, "Open folder"))
     }
 
     private fun openLogsDirectory() {

--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -362,7 +362,9 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun openLocation(directory: File) {
-        val uri: Uri = FileProvider.getUriForFile(this, "$packageName.provider", directory)
+        val relativePath = directory.absolutePath.substringAfter("/storage/emulated/0/")
+        val encoded = Uri.encode(relativePath)
+        val uri = Uri.parse("content://com.android.externalstorage.documents/document/primary%3A$encoded")
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)
             flags = Intent.FLAG_GRANT_READ_URI_PERMISSION


### PR DESCRIPTION
## Summary
- add open location option when saving logs
- let user open the log folder via a folder icon

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685394d8b8ec832995f66d7e61b5c868