### PR TITLE
Refactor Bluetooth helpers

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/BleCallbacks.kt
+++ b/app/src/main/java/com/example/kittmonitor/BleCallbacks.kt
@@ -1,0 +1,108 @@
+package com.example.kittmonitor
+
+import android.bluetooth.*
+import android.util.Log
+import androidx.compose.runtime.MutableState
+import androidx.compose.ui.text.AnnotatedString
+import java.util.UUID
+
+fun createGattCallback(
+    hasPermission: () -> Boolean,
+    descriptorQueue: DescriptorWriteQueue,
+    logMessages: MutableList<AnnotatedString>,
+    isConnectedState: MutableState<Boolean>,
+    statusTextState: MutableState<String>,
+    attemptReconnect: () -> Unit,
+    onStatusChange: (String) -> Unit,
+    onDisconnected: () -> Unit
+): BluetoothGattCallback {
+    fun handleServiceDiscovery(gatt: BluetoothGatt, status: Int) {
+        Log.d("KITTMonitor", "onServicesDiscovered: status=$status")
+        if (status == BluetoothGatt.GATT_SUCCESS && hasPermission()) {
+            onStatusChange("Subscribing...")
+            val targetServiceUUID = UUID.fromString("1982C0DE-D00D-1123-BEEF-C0DEBA5EFEED")
+            val targetCharUUIDs = setOf(
+                UUID.fromString("1982C0DE-D00D-1123-BEEF-C0DEBA5ECBAD"),
+                UUID.fromString("1982C0DE-D00D-1123-BEEF-C0DEBA5EDA70")
+            )
+
+            val service = gatt.getService(targetServiceUUID)
+            if (service != null) {
+                targetCharUUIDs.forEach { uuid ->
+                    val characteristic = service.getCharacteristic(uuid)
+                    if (characteristic != null &&
+                        characteristic.properties and BluetoothGattCharacteristic.PROPERTY_NOTIFY != 0
+                    ) {
+                        gatt.setCharacteristicNotification(characteristic, true)
+                        val descriptor = characteristic.getDescriptor(
+                            UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+                        )
+                        descriptor?.let {
+                            it.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                            descriptorQueue.enqueue(gatt, it)
+                        }
+                    }
+                }
+                statusTextState.value = "KITT Monitor"
+                isConnectedState.value = true
+            } else {
+                Log.w("KITTMonitor", "Target service not found, restarting...")
+                gatt.disconnect()
+            }
+        } else {
+            Log.e("KITTMonitor", "Service discovery failed with status $status")
+            gatt.disconnect()
+        }
+    }
+
+    return object : BluetoothGattCallback() {
+        override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
+            Log.d("KITTMonitor", "onConnectionStateChange: status=$status, newState=$newState")
+            if (newState == BluetoothProfile.STATE_CONNECTED && hasPermission()) {
+                g.discoverServices()
+            } else if (newState == BluetoothProfile.STATE_DISCONNECTED) {
+                onDisconnected()
+                isConnectedState.value = false
+                attemptReconnect()
+            }
+        }
+
+        override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
+            handleServiceDiscovery(gatt, status)
+        }
+
+        override fun onCharacteristicChanged(gatt: BluetoothGatt, characteristic: BluetoothGattCharacteristic) {
+            val value = characteristic.value
+            val raw = value?.decodeToString() ?: ""
+            Log.d("KITTMonitor", "Received update: $raw")
+            val formatted = formatMessage(characteristic.uuid, raw)
+            logMessages.add(formatted)
+        }
+
+        override fun onDescriptorWrite(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor, status: Int) {
+            descriptorQueue.onWriteComplete()
+        }
+    }
+}
+
+fun formatMessage(uuid: UUID, value: String): AnnotatedString {
+    val timestamp = java.time.LocalTime.now().format(java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"))
+    val white = androidx.compose.ui.graphics.Color.White
+    return androidx.compose.ui.text.buildAnnotatedString {
+        withStyle(androidx.compose.ui.text.SpanStyle(color = white)) { append("[$timestamp] ") }
+        when {
+            uuid.toString().uppercase().endsWith("DA70") -> {
+                withStyle(androidx.compose.ui.text.SpanStyle(color = androidx.compose.ui.graphics.Color.Cyan)) { append("DAT ") }
+                withStyle(androidx.compose.ui.text.SpanStyle(color = white)) { append("Voltage: $value") }
+                withStyle(androidx.compose.ui.text.SpanStyle(color = white)) { append("V") }
+            }
+            uuid.toString().uppercase().endsWith("CBAD") -> {
+                withStyle(androidx.compose.ui.text.SpanStyle(color = androidx.compose.ui.graphics.Color.Yellow)) { append("ERR ") }
+                withStyle(androidx.compose.ui.text.SpanStyle(color = white)) { append(value) }
+            }
+            else -> {
+                withStyle(androidx.compose.ui.text.SpanStyle(color = white)) { append(value) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/kittmonitor/DescriptorWriteQueue.kt
+++ b/app/src/main/java/com/example/kittmonitor/DescriptorWriteQueue.kt
@@ -1,0 +1,31 @@
+package com.example.kittmonitor
+
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattDescriptor
+import java.util.concurrent.ConcurrentLinkedQueue
+
+class DescriptorWriteQueue {
+    private val queue = ConcurrentLinkedQueue<Pair<BluetoothGatt, BluetoothGattDescriptor>>()
+    private var isWriting = false
+
+    fun enqueue(gatt: BluetoothGatt, descriptor: BluetoothGattDescriptor) {
+        queue.add(Pair(gatt, descriptor))
+        if (!isWriting) {
+            processNext()
+        }
+    }
+
+    fun onWriteComplete() {
+        isWriting = false
+        processNext()
+    }
+
+    private fun processNext() {
+        val item = queue.poll()
+        if (item != null) {
+            isWriting = true
+            val (gatt, descriptor) = item
+            gatt.writeDescriptor(descriptor)
+        }
+    }
+}

--- a/app/src/main/java/com/example/kittmonitor/TerminalView.kt
+++ b/app/src/main/java/com/example/kittmonitor/TerminalView.kt
@@ -1,0 +1,73 @@
+package com.example.kittmonitor
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.LaunchedEffect
+
+@Composable
+fun TerminalView(
+    logs: List<AnnotatedString>,
+    followBottom: Boolean,
+    onFollowBottomChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val listState = rememberLazyListState()
+    var programmaticScroll by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(logs.size, followBottom) {
+        if (followBottom && logs.isNotEmpty()) {
+            programmaticScroll = true
+            listState.animateScrollToItem(logs.size - 1)
+            programmaticScroll = false
+        }
+    }
+
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.isScrollInProgress }
+            .collect { inProgress ->
+                if (inProgress && !programmaticScroll) {
+                    val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+                    if (lastVisible < logs.size - 1) {
+                        onFollowBottomChange(false)
+                    }
+                }
+            }
+    }
+
+    LazyColumn(
+        state = listState,
+        modifier = modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures(onDoubleTap = {
+                    onFollowBottomChange(true)
+                    programmaticScroll = true
+                    scope.launch {
+                        listState.animateScrollToItem(logs.size - 1)
+                        programmaticScroll = false
+                    }
+                })
+            }
+    ) {
+        items(logs) { message ->
+            Text(
+                text = message,
+                color = Color.Unspecified,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/kittmonitor/TerminalView.kt
+++ b/app/src/main/java/com/example/kittmonitor/TerminalView.kt
@@ -53,11 +53,13 @@ fun TerminalView(
             .fillMaxSize()
             .pointerInput(Unit) {
                 detectTapGestures(onDoubleTap = {
-                    onFollowBottomChange(true)
-                    programmaticScroll = true
-                    scope.launch {
-                        listState.animateScrollToItem(logs.size - 1)
-                        programmaticScroll = false
+                    if (logs.isNotEmpty()) {
+                        onFollowBottomChange(true)
+                        programmaticScroll = true
+                        scope.launch {
+                            listState.animateScrollToItem(logs.size - 1)
+                            programmaticScroll = false
+                        }
                     }
                 })
             }


### PR DESCRIPTION
## Summary
- extract `TerminalView` composable into its own file
- introduce `DescriptorWriteQueue` class for descriptor writes
- update `MainActivity` to use the new helper and clean up imports

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to download Gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6853a1fa79a48329863b30d15bc397d2