### PR TITLE
Save logs to Documents

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -18,6 +18,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -171,19 +172,18 @@ class MainActivity : ComponentActivity() {
     @RequiresApi(Build.VERSION_CODES.O)
     private fun saveLogsToFile() {
         val text = logMessages.joinToString("\n") { it.text }
-        val dir = getExternalFilesDir(null)
-        dir?.let {
-            val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMddHHmmss"))
-            val file = File(it, "log_${timestamp}.txt")
-            try {
-                file.writeText(text)
-                logMessages.clear()
-                Log.d("KITTMonitor", "Logs saved to ${file.absolutePath}")
-                showFileDialog(file)
-            } catch (e: Exception) {
-                Toast.makeText(this, "Failed to save logs", Toast.LENGTH_LONG).show()
-                Log.e("KITTMonitor", "Failed to save logs", e)
-            }
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+        if (!dir.exists()) dir.mkdirs()
+        val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMddHHmmss"))
+        val file = File(dir, "log_${timestamp}.txt")
+        try {
+            file.writeText(text)
+            logMessages.clear()
+            Log.d("KITTMonitor", "Logs saved to ${file.absolutePath}")
+            showFileDialog(file)
+        } catch (e: Exception) {
+            Toast.makeText(this, "Failed to save logs", Toast.LENGTH_LONG).show()
+            Log.e("KITTMonitor", "Failed to save logs", e)
         }
     }
 


### PR DESCRIPTION
## Summary
- store log files in Android's public Documents directory

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853a8ad855c832992f157bffa18db21