### PR TITLE
Add landscape graph and orientation control

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/MainScreen.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainScreen.kt
@@ -16,23 +16,33 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import android.content.res.Configuration
 import com.example.kittmonitor.ui.theme.KITTMonitorTheme
+import com.example.kittmonitor.VoltageGraph
 
 @Composable
 fun MainScreen(
     isConnectedState: MutableState<Boolean>,
     statusTextState: MutableState<String>,
     logMessages: MutableList<AnnotatedString>,
+    voltageData: MutableList<Pair<Long, Float>>,
     followBottomState: MutableState<Boolean>,
     bluetoothAdapter: BluetoothAdapter,
     saveLogsToFile: () -> Unit,
     openLogsFolder: () -> Unit,
     hasPermission: () -> Boolean,
-    beginConnectionFlow: () -> Unit
+    beginConnectionFlow: () -> Unit,
+    setOrientationAllowed: (Boolean) -> Unit
 ) {
     val activity = LocalContext.current as Activity
+    val configuration = LocalConfiguration.current
+
+    LaunchedEffect(isConnectedState.value) {
+        setOrientationAllowed(isConnectedState.value)
+    }
 
     KITTMonitorTheme {
         Scaffold(modifier = Modifier.fillMaxSize()) { padding ->
@@ -98,12 +108,19 @@ fun MainScreen(
                     }
                 }
                 if (isConnectedState.value) {
-                    TerminalView(
-                        logs = logMessages,
-                        followBottom = followBottomState.value,
-                        onFollowBottomChange = { followBottomState.value = it },
-                        modifier = Modifier.weight(1f)
-                    )
+                    if (configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                        VoltageGraph(
+                            data = voltageData,
+                            modifier = Modifier.weight(1f)
+                        )
+                    } else {
+                        TerminalView(
+                            logs = logMessages,
+                            followBottom = followBottomState.value,
+                            onFollowBottomChange = { followBottomState.value = it },
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
                 } else {
                     Spacer(modifier = Modifier.weight(1f))
                 }

--- a/app/src/main/java/com/example/kittmonitor/VoltageGraph.kt
+++ b/app/src/main/java/com/example/kittmonitor/VoltageGraph.kt
@@ -1,0 +1,69 @@
+package com.example.kittmonitor
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.Canvas
+
+@Composable
+fun VoltageGraph(
+    data: List<Pair<Long, Float>>,
+    modifier: Modifier = Modifier
+) {
+    if (data.isEmpty()) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .background(Color.Black),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "No data",
+                color = Color.White,
+                style = MaterialTheme.typography.bodyLarge
+            )
+        }
+        return
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Black)
+    ) {
+        val padding = 16.dp.toPx()
+        val width = size.width - 2 * padding
+        val height = size.height - 2 * padding
+
+        val xMin = data.first().first.toFloat()
+        val xMax = data.last().first.toFloat()
+        val yMin = data.minOf { it.second }
+        val yMax = data.maxOf { it.second }
+
+        val xRange = if (xMax - xMin == 0f) 1f else xMax - xMin
+        val yRange = if (yMax - yMin == 0f) 1f else yMax - yMin
+
+        val path = Path()
+        data.forEachIndexed { index, (time, value) ->
+            val x = padding + ((time - xMin) / xRange) * width
+            val y = size.height - padding - ((value - yMin) / yRange) * height
+            if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        drawPath(
+            path = path,
+            color = Color.Cyan,
+            style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round)
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- draw a simple voltage line graph using Compose `Canvas`
- show the graph when the device is rotated to landscape
- lock orientation to portrait until a BLE connection is made
- unlock orientation after connection and re-lock on disconnect
- track voltage data for graph plotting

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853b40327fc8329b4f64607a4d81eaf