### PR TITLE
Add KITT scanner animation for connection state

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/BleCallbacks.kt
+++ b/app/src/main/java/com/example/kittmonitor/BleCallbacks.kt
@@ -12,15 +12,12 @@ fun createGattCallback(
     descriptorQueue: DescriptorWriteQueue,
     logMessages: MutableList<AnnotatedString>,
     isConnectedState: MutableState<Boolean>,
-    statusTextState: MutableState<String>,
     attemptReconnect: () -> Unit,
-    onStatusChange: (String) -> Unit,
     onDisconnected: () -> Unit
 ): BluetoothGattCallback {
     fun handleServiceDiscovery(gatt: BluetoothGatt, status: Int) {
         Log.d("KITTMonitor", "onServicesDiscovered: status=$status")
         if (status == BluetoothGatt.GATT_SUCCESS && hasPermission()) {
-            onStatusChange("Subscribing...")
             val targetServiceUUID = UUID.fromString("1982C0DE-D00D-1123-BEEF-C0DEBA5EFEED")
             val targetCharUUIDs = setOf(
                 UUID.fromString("1982C0DE-D00D-1123-BEEF-C0DEBA5ECBAD"),
@@ -44,7 +41,6 @@ fun createGattCallback(
                         }
                     }
                 }
-                statusTextState.value = "KITT Monitor"
                 isConnectedState.value = true
             } else {
                 Log.w("KITTMonitor", "Target service not found, restarting...")

--- a/app/src/main/java/com/example/kittmonitor/KITTScanner.kt
+++ b/app/src/main/java/com/example/kittmonitor/KITTScanner.kt
@@ -1,0 +1,47 @@
+package com.example.kittmonitor
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+
+@Composable
+fun KITTScanner(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "scanner")
+    val position by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "scannerPosition"
+    )
+
+    Canvas(modifier = modifier) {
+        val width = size.width
+        val height = size.height
+        val segment = width * 0.1f
+        val center = position * width
+        val alphas = listOf(0.2f, 0.5f, 1f, 0.5f, 0.2f)
+        alphas.forEachIndexed { index, alpha ->
+            val x = center + (index - 2) * segment
+            drawRoundRect(
+                color = Color.Red.copy(alpha = alpha),
+                topLeft = Offset(x - segment / 2f, 0f),
+                size = Size(segment, height),
+                cornerRadius = CornerRadius(height / 2f, height / 2f)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/kittmonitor/MainScreen.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainScreen.kt
@@ -19,11 +19,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.example.kittmonitor.ui.theme.KITTMonitorTheme
+import com.example.kittmonitor.KITTScanner
 
 @Composable
 fun MainScreen(
     isConnectedState: MutableState<Boolean>,
-    statusTextState: MutableState<String>,
     logMessages: MutableList<AnnotatedString>,
     followBottomState: MutableState<Boolean>,
     bluetoothAdapter: BluetoothAdapter,
@@ -79,11 +79,19 @@ fun MainScreen(
                         modifier = Modifier.weight(1f),
                         contentAlignment = Alignment.Center
                     ) {
-                        Text(
-                            text = statusTextState.value,
-                            color = Color.White,
-                            style = MaterialTheme.typography.bodyLarge
-                        )
+                        if (isConnectedState.value) {
+                            Text(
+                                text = "KITT Monitor",
+                                color = Color.White,
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                        } else {
+                            KITTScanner(
+                                modifier = Modifier
+                                    .height(20.dp)
+                                    .fillMaxWidth(0.6f)
+                            )
+                        }
                     }
                     Box(
                         modifier = Modifier.weight(1f),


### PR DESCRIPTION
## Summary
- remove dynamic status updates
- hide header text until connected
- add animated KITT scanner while connecting

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853b76283f483299e1d5218700cbb99