### PR TITLE
Fix bluetooth prompt on resume

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -227,6 +227,10 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         registerReceiver(bluetoothStateReceiver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
+        if (hasPermission() && !bluetoothAdapter.isEnabled) {
+            val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
+            startActivityForResult(enableBtIntent, 1)
+        }
     }
 
     override fun onPause() {


### PR DESCRIPTION
## Summary
- ensure returning from background triggers bluetooth enable prompt if bluetooth is off

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6853c098d25c83299c18b5ede2c3764f