### PR TITLE
Fix logs directory

### DIFF
--- a/app/src/main/java/com/example/kittmonitor/MainActivity.kt
+++ b/app/src/main/java/com/example/kittmonitor/MainActivity.kt
@@ -180,8 +180,8 @@ class MainActivity : ComponentActivity() {
     @RequiresApi(Build.VERSION_CODES.O)
     private fun saveLogsToFile() {
         val text = logMessages.joinToString("\n") { it.text }
-        val docsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
-        val dir = File(docsDir, "KITT Logs")
+        val downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        val dir = File(downloadsDir, "KITT Logs")
         if (!dir.exists()) dir.mkdirs()
         val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("MMddHHmmss"))
         val file = File(dir, "log_${timestamp}.txt")
@@ -189,7 +189,7 @@ class MainActivity : ComponentActivity() {
             file.writeText(text)
             logMessages.clear()
             Log.d("KITTMonitor", "Logs saved to ${file.absolutePath}")
-            showFileDialog(file, "/Documents/${dir.name}/${file.name}")
+            showFileDialog(file, "/Download/${dir.name}/${file.name}")
         } catch (e: Exception) {
             Toast.makeText(this, "Failed to save logs", Toast.LENGTH_LONG).show()
             Log.e("KITTMonitor", "Failed to save logs", e)
@@ -198,7 +198,7 @@ class MainActivity : ComponentActivity() {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun openLogsFolder() {
-        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS)
+        val dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
         val uri: Uri = FileProvider.getUriForFile(this, "$packageName.provider", dir)
         val intent = Intent(Intent.ACTION_VIEW).apply {
             setDataAndType(uri, DocumentsContract.Document.MIME_TYPE_DIR)


### PR DESCRIPTION
## Summary
- save logs in the Downloads directory instead of Documents

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6854d76eaaa88329960fa277b7e10462